### PR TITLE
feat: skip delay for private vaults

### DIFF
--- a/packages/replicating/src/contracts/replicating_solver.cairo
+++ b/packages/replicating/src/contracts/replicating_solver.cairo
@@ -338,9 +338,11 @@ pub mod ReplicatingSolver {
 
             // Run checks.
             self.solver.assert_market_owner(market_id);
+            let market_info: MarketInfo = self.solver.market_info.read(market_id);
             assert(params != queued_params, 'ParamsUnchanged');
-            if params != Default::default() {
-                // Skip this check if we are initialising the market for first time.
+            // Skip this check if we are initialising the market for first time, or
+            // if the market is private.
+            if params != Default::default() && market_info.is_public {
                 assert(queued_at + delay <= get_block_timestamp(), 'DelayNotPassed');
             }
             assert(queued_at != 0 && queued_params != Default::default(), 'NotQueued');

--- a/packages/replicating/src/tests/solver.cairo
+++ b/packages/replicating/src/tests/solver.cairo
@@ -9,3 +9,4 @@ pub mod test_oracle;
 // Disabled - used for debugging of live vaults
 // pub mod debug_swap;
 
+

--- a/scripts/sepolia.sh
+++ b/scripts/sepolia.sh
@@ -16,7 +16,7 @@ export ORACLE=0x36031daa264c24520b11d93af622c848b2499b66b41d611bac95e13cfca131a
 # Vault token
 starkli declare --rpc $STARKNET_RPC --account $STARKNET_ACCOUNT --keystore $STARKNET_KEYSTORE '/Users/parkyeung/dev/solver/target/dev/haiko_solver_replicating_VaultToken.contract_class.json'
 
-# Solver
+# Replicating Solver
 starkli declare --rpc $STARKNET_RPC --account $STARKNET_ACCOUNT --keystore $STARKNET_KEYSTORE '/Users/parkyeung/dev/solver/target/dev/haiko_solver_replicating_ReplicatingSolver.contract_class.json'
 
 #############################
@@ -29,6 +29,9 @@ starkli deploy --rpc $STARKNET_RPC $REPLICATING_SOLVER_CLASS $OWNER $ORACLE $VAU
 #############################
 # Deployments
 #############################
+
+# 22 August 2024
+export REPLICATING_SOLVER_CLASS=0x0589858bd41fc0c922ff5c656f3373f7072fb8a69fcd02c8cdad0dce6666d4fb
 
 # 21 August 2024
 export REPLICATING_SOLVER_CLASS=0x058f847593deac850a96bdf55c0b60431985a7235201b3b55b96e12f4be54472


### PR DESCRIPTION
## Summary

The Replicating Solver currently sets a global delay for updating market parameters through a queuing mechanism. Market owners must queue new market param updates, then wait for the delay to pass before confirming / setting the market parameters.

This PR removes the requirement for private vaults by skipping the delay immediately. We also add a new test case to handle this scenario.

## Testing
```
snforge test
```